### PR TITLE
Create a target/lib/perl directory during builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,7 @@
 		  <globmapper from="cdp-listend" to="cdp-listend.pod" />
 		</mapper>
 	      </move>
+	      <mkdir dir="${project.build.directory}/lib/perl"/>
 	    </tasks>
 	  </configuration>
 	</execution>


### PR DESCRIPTION
The parent POM file expects such a directory. Otherwise we get an
annoying warning at build time.

Fixes #5
