### PR TITLE
Use a standard location for scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
                 </sources>
               </mapping>
               <mapping>
-                <directory>/usr/quattor/scripts</directory>
+                <directory>/usr/share/quattor</directory>
                 <filemode>755</filemode>
                 <documentation>false</documentation>
                 <directoryIncluded>false</directoryIncluded>


### PR DESCRIPTION
This location matches where CCM places a tabcompletion script.

Backwards incompatible if these scripts have been configured for use in a monitoring system.