### PR TITLE
Add chkconfig as an rpm dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
             <requires>
               <require>crontabs</require>
               <require>logrotate</require>
+              <require>chkconfig</require>
             </requires>
             <preinstallScriptlet>
               <script><![CDATA[


### PR DESCRIPTION
Add chkconfig as an rpm dependency to mitigate the impact of #27.